### PR TITLE
Link existing Block to rendering code

### DIFF
--- a/src/ChangelogEmbed/API.php
+++ b/src/ChangelogEmbed/API.php
@@ -86,11 +86,29 @@ class API {
 		$branch       = $request->get_param( 'branch' );
 		$max_versions = $request->get_param( 'max_versions' );
 
+		$changelog_parser = new Changelog_Parser();
+		$cache            = new Cache();
+
+		$cache_key   = $owner . '_' . $repo . '_' . $path . '_' . $branch . '_' . $max_versions;
+		$cached_data = $cache->get( $cache_key );
+
+		if ( $cached_data ) {
+			if ( is_wp_error( $cached_data ) ) {
+				return rest_ensure_response( $cached_data );
+			}
+
+			$changelog_data = $changelog_parser->parse( $cached_data, $max_versions );
+
+			return rest_ensure_response( $changelog_data );
+		}
+
 		// Get GitHub API instance.
 		$github_api = new GitHub_API();
 
 		// Fetch changelog content.
 		$changelog_content = $github_api->get_file_content( $owner, $repo, $path, $branch );
+
+		$cache->set( $cache_key, $changelog_content );
 
 		if ( is_wp_error( $changelog_content ) ) {
 			return rest_ensure_response( $changelog_content );

--- a/src/ChangelogEmbed/GitHub_API.php
+++ b/src/ChangelogEmbed/GitHub_API.php
@@ -66,7 +66,7 @@ class GitHub_API {
 		// Set up request arguments.
 		$args = [
 			'headers' => [
-				'Accept'     => 'application/vnd.github.v3.raw',
+				'Accept'     => 'application/vnd.github.v4.raw',
 				'User-Agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ),
 			],
 			'timeout' => 30,

--- a/src/ChangelogEmbed/Plugin.php
+++ b/src/ChangelogEmbed/Plugin.php
@@ -9,6 +9,8 @@
 
 namespace StellarWP\ChangelogEmbed;
 
+use WP_REST_Request;
+
 /**
  * Plugin class.
  *
@@ -57,36 +59,22 @@ class Plugin {
 	 * @return string|\WP_Error
 	 */
 	public function render( $attributes ) {
-		// Get the URL from the block attributes.
-		$changelog_url = isset( $attributes['changelogUrl'] ) ? esc_url_raw( $attributes['changelogUrl'] ) : '';
+		$request = new WP_REST_Request();
 
-		// If no URL is provided, display a message.
-		if ( empty( $changelog_url ) ) {
-			return '';
+		foreach ( $attributes as $key => $value ) {
+			$request->set_param( $key, $value );
 		}
 
-		// Fetch the contents of the text file.
-		$response = wp_remote_get( $changelog_url );
+		$api      = new API();
+		$response = $api->get_changelog( $request );
 
-		if ( is_wp_error( $response ) ) {
-			return '';
-		}
+		$changelog_data = $response->get_data();
 
-		$body = wp_remote_retrieve_body( $response );
-
-		// Replace each backtick-enclosed text with a <code> tag.
-		$body = preg_replace( '/`([^`]+)`/', '<code>$1</code>', $body );
-
-		// Make headings <h3> tags.
-		$body = preg_replace( '/= \[(\d+\.\d+\.\d+)\] =/', "\n<h3>$1</h3>", $body );
-
-		// Replace each asterisk at the beginning of a line with a list item <li>.
-		$body = preg_replace( '/^\* (.+)/m', '<li>$1</li>', $body );
-
-		// Wrap all groups of list items in an unordered list <ul>.
-		$body = preg_replace( '/(<li>.+<\/li>\n)+/', '<ul>$0</ul>', $body );
+		ob_start();
+		include_once STELLAR_CHANGELOG_EMBED_DIR . '/src/views/changelog.php';
+		$template = (string) ob_get_clean();
 
 		// Return the contents of the text file.
-		return wp_kses_post( $body );
+		return wp_kses_post( $template );
 	}
 }

--- a/src/modules/blocks/changelog-embed/block.json
+++ b/src/modules/blocks/changelog-embed/block.json
@@ -15,9 +15,25 @@
         "64756b"
     ],
     "attributes": {
-        "changelogUrl": {
+        "owner": {
             "type": "string",
             "default": ""
+        },
+        "repo": {
+            "type": "string",
+            "default": ""
+        },
+        "path": {
+            "type": "string",
+            "default": ""
+        },
+        "branch": {
+            "type": "string",
+            "default": "main"
+        },
+        "max_versions": {
+            "type": "integer",
+            "default": 5
         }
     },
     "textdomain": "stellarwp-changelog-embed",

--- a/src/modules/blocks/changelog-embed/edit.js
+++ b/src/modules/blocks/changelog-embed/edit.js
@@ -33,10 +33,33 @@ export default function Edit(props) {
 			<InspectorControls>
 				<div className="block-editor-block-card">
 					<TextControl
-						label="Changelog URL"
-						value={attributes.changelogUrl}
-						onChange={(newUrl) => setAttributes({ changelogUrl: newUrl })}
-						help="Enter the URL of the changelog file you want to display."
+						label="Owner"
+						value={attributes.owner}
+						onChange={(newOwner) => setAttributes({ owner: newOwner })}
+					/>
+
+					<TextControl
+						label="Repo"
+						value={attributes.repo}
+						onChange={(newRepo) => setAttributes({ repo: newRepo })}
+					/>
+
+					<TextControl
+						label="Path"
+						value={attributes.path}
+						onChange={(newPath) => setAttributes({ path: newPath })}
+					/>
+
+					<TextControl
+						label="Branch"
+						value={attributes.branch}
+						onChange={(newBranch) => setAttributes({ branch: newBranch })}
+					/>
+
+					<TextControl
+						label="Max Versions"
+						value={attributes.max_versions}
+						onChange={(newMaxVersions) => setAttributes({ max_versions: newMaxVersions })}
 					/>
 				</div>
 			</InspectorControls>

--- a/src/modules/blocks/changelog-embed/edit.js
+++ b/src/modules/blocks/changelog-embed/edit.js
@@ -7,6 +7,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { TextControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
 
 /**
  * The edit function describes the structure of your block in the context of the
@@ -23,7 +24,7 @@ export default function Edit(props) {
 	let changelogUrlInfo = null;
 
 	if ( ! attributes.changelogUrl ) {
-		changelogUrlInfo = (<span style={{ color: '#999', fontSize: '1rem' }}>Set the changelog URL in the sidebar.</span>);
+		changelogUrlInfo = (<span style={{ color: '#999', fontSize: '1rem' }}>{__("Configure in the sidebar.", "stellar-changelog-embed")}</span>);
 	} else {
 		changelogUrlInfo = (<a href={attributes.changelogUrl} target="_blank">{attributes.changelogUrl}</a>);
 	}
@@ -34,31 +35,31 @@ export default function Edit(props) {
 			<InspectorControls>
 				<div className="block-editor-block-card">
 					<TextControl
-						label="Owner"
+						label={__("Owner", "stellar-changelog-embed")}
 						value={attributes.owner}
 						onChange={(newOwner) => setAttributes({ owner: newOwner })}
 					/>
 
 					<TextControl
-						label="Repo"
+						label={__("Repo", "stellar-changelog-embed")}
 						value={attributes.repo}
 						onChange={(newRepo) => setAttributes({ repo: newRepo })}
 					/>
 
 					<TextControl
-						label="Path"
+						label={__("Path", "stellar-changelog-embed")}
 						value={attributes.path}
 						onChange={(newPath) => setAttributes({ path: newPath })}
 					/>
 
 					<TextControl
-						label="Branch"
+						label={__("Branch", "stellar-changelog-embed")}
 						value={attributes.branch}
 						onChange={(newBranch) => setAttributes({ branch: newBranch })}
 					/>
 
 					<TextControl
-						label="Max Versions"
+						label={__("Max Versions", "stellar-changelog-embed")}
 						value={attributes.max_versions}
 						onChange={(newMaxVersions) => setAttributes({ max_versions: newMaxVersions })}
 					/>
@@ -67,7 +68,7 @@ export default function Edit(props) {
 
 			<div {...blockProps}>
 				<div style={{ backgroundColor: '#f0f0f0', border: '1px solid #000', padding: '1rem' }}>
-					Changelog Embed <span style={{ color: '#999', fontSize: '0.8rem' }}>(this box is not visible in the frontend)</span>
+					{__("Changelog Embed", "stellar-changelog-embed")} <span style={{ color: '#999', fontSize: '0.8rem' }}>({__("this box is not visible in the frontend", "stellar-changelog-embed")})</span>
 					<div>{changelogUrlInfo}</div>
 				</div>
 

--- a/src/modules/blocks/changelog-embed/edit.js
+++ b/src/modules/blocks/changelog-embed/edit.js
@@ -28,6 +28,7 @@ export default function Edit(props) {
 		changelogUrlInfo = (<a href={attributes.changelogUrl} target="_blank">{attributes.changelogUrl}</a>);
 	}
 
+  // TODO: Improve the styling of the inspector controls.
   return (
 		<Fragment>
 			<InspectorControls>

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -102,7 +102,6 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 									<?php echo esc_html( $type ); ?>
 								</span>
 								<span class="stellar-changelog-embed__section-count">
-									<?php // TODO: Investigate what the previous code did here. ?>
 									<?php echo count( $changes ); ?>
 								</span>
 							</h4>
@@ -110,6 +109,7 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 							<ul class="stellar-changelog-embed__changes">
 								<?php foreach ( $changes as $change ) : ?>
 									<li class="stellar-changelog-embed__change">
+										<?php // TODO: Investigate what the previous code did here. ?>
 										<?php echo wp_kses_post( $change ); ?>
 									</li>
 								<?php endforeach; ?>

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -98,9 +98,11 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 						<div class="stellar-changelog-embed__section">
 							<h4 class="stellar-changelog-embed__section-header">
 								<span class="stellar-changelog-embed__section-title">
+									<?php // TODO: Pluralize the type. ?>
 									<?php echo esc_html( $type ); ?>
 								</span>
 								<span class="stellar-changelog-embed__section-count">
+									<?php // TODO: Investigate what the previous code did here. ?>
 									<?php echo count( $changes ); ?>
 								</span>
 							</h4>

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -98,7 +98,7 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 						<div class="stellar-changelog-embed__section">
 							<h4 class="stellar-changelog-embed__section-header">
 								<span class="stellar-changelog-embed__section-title">
-									<?php echo esc_html( Stellar_Changelog_Embed::pluralize_change_type( $type ) ); ?>
+									<?php echo esc_html( $type ); ?>
 								</span>
 								<span class="stellar-changelog-embed__section-count">
 									<?php echo count( $changes ); ?>
@@ -108,7 +108,7 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 							<ul class="stellar-changelog-embed__changes">
 								<?php foreach ( $changes as $change ) : ?>
 									<li class="stellar-changelog-embed__change">
-										<?php echo wp_kses_post( Stellar_Changelog_Embed::process_changelog_content( $change ) ); ?>
+										<?php echo wp_kses_post( $change ); ?>
 									</li>
 								<?php endforeach; ?>
 							</ul>


### PR DESCRIPTION
It isn't the most amazing code in the world, but this is the quickest way to get the two codebases communicating.

Once the Settings page has been added (separate PR) this will be _usable_, but not accessible or remotely nice to look at.