### PR TITLE
Fix date capture

### DIFF
--- a/src/ChangelogEmbed/Changelog_Parser.php
+++ b/src/ChangelogEmbed/Changelog_Parser.php
@@ -44,7 +44,7 @@ class Changelog_Parser {
 			}
 
 			// Check for version headers (e.g., "= [4.21.1] =", "= [4.21.1] 2025-08-07 =").
-			if ( preg_match( '/^=\s*\[([^\]]+)\]\s*(?:(?:[^=])+)? =$/i', $line, $matches ) ) {
+			if ( preg_match( '/^=\s*\[([^\]]+)\]\s*((?:[^=])+)?\s*=$/i', $line, $matches ) ) {
 				// If we've hit the max versions, stop processing.
 				if ( count( $changelog_data ) >= $max_versions ) {
 					break;

--- a/src/ChangelogEmbed/Changelog_Parser.php
+++ b/src/ChangelogEmbed/Changelog_Parser.php
@@ -44,7 +44,7 @@ class Changelog_Parser {
 			}
 
 			// Check for version headers (e.g., "= [4.21.1] =", "= [4.21.1] 2025-08-07 =").
-			if ( preg_match( '/^=\s*\[([^\]]+)\]\s*((?:[^=])+)?\s*=$/i', $line, $matches ) ) {
+			if ( preg_match( '/^=\s*\[([^\]]+)\]\s*([^=]+)?\s*=$/i', $line, $matches ) ) {
 				// If we've hit the max versions, stop processing.
 				if ( count( $changelog_data ) >= $max_versions ) {
 					break;

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -66,7 +66,8 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 								echo esc_html(
 									wp_date(
 										get_option( 'date_format', 'F j, Y' ),
-										strtotime( $version['date'] ) // Assumes UTC for release, so depending on your timezone it may look "off".
+										strtotime( $version['date'] ), // Assumes UTC for release.
+										new DateTimeZone( 'UTC' ) // Force UTC to avoid issues with different site timezones.
 									)
 								);
 								?>

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -65,7 +65,7 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 								<?php
 								echo esc_html(
 									wp_date(
-										get_option( 'date_format', 'F d, Y' ),
+										get_option( 'date_format', 'F j, Y' ),
 										strtotime( $version['date'] ) // Assumes UTC for release, so depending on your timezone it may look "off".
 									)
 								);

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -62,7 +62,14 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 								<span class="screen-reader-text">
 									<?php esc_html_e( 'Released on:', 'stellar-changelog-embed' ); ?>
 								</span>
-								<?php echo esc_html( $version['date'] ); ?>
+								<?php
+								echo esc_html(
+									wp_date(
+										get_option( 'date_format', 'F d, Y' ),
+										strtotime( $version['date'] ) // Assumes UTC for release, so depending on your timezone it may look "off".
+									)
+								);
+								?>
 							</span>
 						<?php endif; ?>
 						


### PR DESCRIPTION
The RegEx needed to be adjusted so that the date could be captured by the Changelog Parser.

Example JSON from the API Endpoint, with and without a date for the changelog:

```json
[
  {
    "version": "4.23.2.1",
    "date": "2025-07-24",
    "isLatest": true,
    "changes": [
      {
        "type": "Fix",
        "content": "Resolved an issue where the \"View\" and \"Trash\" links for Orders were missing from the Orders listing screen."
      }
    ]
  },
  {
    "version": "4.23.2",
    "date": "",
    "isLatest": false,
    "changes": [
      {
        "type": "Fix",
        "content": "Resolved an issue where \"Fill in the blanks\" question answer result indicators would overlap when the question contained multiple answer inputs across multiple lines."
      },
      ...
    ]
  },
  ...
]
```

Really bad looking frontend output showing that it conditionally shows the date set using the site's timezone:

<img width="1223" height="391" alt="image" src="https://github.com/user-attachments/assets/ba63ec4c-1a7c-4a68-81b3-0bd51475edc4" />