### PR TITLE
Fix code blocks in changelogs

### DIFF
--- a/src/ChangelogEmbed/Changelog_Parser.php
+++ b/src/ChangelogEmbed/Changelog_Parser.php
@@ -72,29 +72,27 @@ class Changelog_Parser {
 				$type    = trim( $matches[1] );
 				$content = trim( $matches[2] );
 
+				global $shortcode_tags;
+
+				$registered_shortcodes = array_map(
+					function ( $tag ) {
+						return preg_quote( $tag, '/' );
+					},
+					array_keys( $shortcode_tags )
+				);
+
+				// Escape shortcodes that exist on this site by adding extra square brackets.
+				$content = preg_replace(
+					'/\[(' . implode( '|', $registered_shortcodes ) . ')\]/',
+					'[[$1]]',
+					$content
+				);
+
 				// Wrap text in backticks with <code> tags and double-escape shortcodes.
 				$content = preg_replace_callback(
 					'/`([^`]+)`/',
 					function ( $matches ) {
-						$code_content = $matches[1];
-
-						global $shortcode_tags;
-
-						$registered_shortcodes = array_map(
-							function ( $tag ) {
-								return preg_quote( $tag, '/' );
-							},
-							array_keys( $shortcode_tags )
-						);
-
-						// Escape shortcodes that exist on this site by adding extra square brackets.
-						$code_content = preg_replace(
-							'/\[(' . implode( '|', $registered_shortcodes ) . ')\]/',
-							'[[$1]]',
-							$code_content
-						);
-
-						return '<code>' . esc_html( $code_content ) . '</code>';
+						return '<code>' . esc_html( $matches[1] ) . '</code>';
 					},
 					$content
 				);

--- a/src/ChangelogEmbed/Changelog_Parser.php
+++ b/src/ChangelogEmbed/Changelog_Parser.php
@@ -72,6 +72,33 @@ class Changelog_Parser {
 				$type    = trim( $matches[1] );
 				$content = trim( $matches[2] );
 
+				// Wrap text in backticks with <code> tags and double-escape shortcodes.
+				$content = preg_replace_callback(
+					'/`([^`]+)`/',
+					function ( $matches ) {
+						$code_content = $matches[1];
+
+						global $shortcode_tags;
+
+						$registered_shortcodes = array_map(
+							function ( $tag ) {
+								return preg_quote( $tag, '/' );
+							},
+							array_keys( $shortcode_tags )
+						);
+
+						// Escape shortcodes that exist on this site by adding extra square brackets.
+						$code_content = preg_replace(
+							'/\[(' . implode( '|', $registered_shortcodes ) . ')\]/',
+							'[[$1]]',
+							$code_content
+						);
+
+						return '<code>' . esc_html( $code_content ) . '</code>';
+					},
+					$content
+				);
+
 				$change = [
 					'type'    => $type,
 					'content' => $content,

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -23,7 +23,7 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 	<div class="stellar-changelog-embed__no-entries">
 		<?php esc_html_e( 'No changelog entries found.', 'stellar-changelog-embed' ); ?>
 	</div>
-<?php else: ?>
+<?php else : ?>
 	<div
 		class="stellar-changelog-embed" 
 		data-versions-per-page="<?php echo esc_attr( $versions_per_page ); ?>" 


### PR DESCRIPTION
These now render properly.

Additionally, existing shortcodes within changelog items no longer attempt to render on the frontend.

Example: 
<img width="1203" height="294" alt="image" src="https://github.com/user-attachments/assets/26011a09-74e0-43ed-bd30-cea234b4e871" />

Note: I know the order of the changelog items is somehow wrong. Need to figure out how that's happening. 