### PR TITLE
Move over styles/js from other plugin

### DIFF
--- a/src/ChangelogEmbed/Plugin.php
+++ b/src/ChangelogEmbed/Plugin.php
@@ -91,6 +91,31 @@ class Plugin {
 		$template = (string) ob_get_clean();
 
 		// Return the contents of the text file.
-		return wp_kses_post( $template );
+
+		$allowed_html = wp_kses_allowed_html( 'post' );
+
+		$allowed_html = wp_parse_args(
+			$allowed_html,
+			[
+				'div' => [],
+			]
+		);
+
+		$allowed_html['div'] = wp_parse_args(
+			$allowed_html['div'],
+			[
+				'data-type'              => true,
+				'data-page'              => true,
+				'data-total-versions'    => true,
+				'data-version-index'     => true,
+				'data-version'           => true,
+				'data-versions-per-page' => true,
+			]
+		);
+
+		return wp_kses(
+			$template,
+			$allowed_html
+		);
 	}
 }

--- a/src/modules/blocks/changelog-embed/block.json
+++ b/src/modules/blocks/changelog-embed/block.json
@@ -37,5 +37,7 @@
         }
     },
     "textdomain": "stellarwp-changelog-embed",
-    "editorScript": "file:./index.js"
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "viewScript": [ "jquery", "file:./frontend.js" ]
 }

--- a/src/modules/blocks/changelog-embed/frontend.js
+++ b/src/modules/blocks/changelog-embed/frontend.js
@@ -1,95 +1,109 @@
 /**
- * Frontend JavaScript for Changelog Viewer
+ * Frontend JavaScript for Changelog Viewer.
  * 
- * Handles toggling of changelog versions, sections, and pagination
+ * Handles toggling of changelog versions, sections, and pagination.
+ * 
+ * @since 2.0.0
+ * 
+ * @param {jQuery} $ The jQuery object.
+ * 
+ * @return {void}
  */
 (function($) {
     'use strict';
     
     /**
-     * Initialize the changelog functionality
+     * Initialize the changelog functionality.
+	 * 
+	 * @since 2.0.0
+	 * 
+	 * @return {void}
      */
     function initChangelog() {
-        // Initialize pagination for each changelog viewer
+        // Initialize pagination for each changelog viewer.
         $('.wp-changelog-viewer').each(function() {
             initPagination($(this));
         });
         
-        // Handle version header clicks
+        // Handle version header clicks.
         $('.stellar-changelog-embed__version-header').on('click', function() {
             const $header = $(this);
             const $version = $header.closest('.stellar-changelog-embed__version');
             const $content = $version.find('.stellar-changelog-embed__version-content');
             const $toggle = $header.find('.stellar-changelog-embed__toggle');
             
-            // Toggle display
+            // Toggle display.
             $content.slideToggle(200);
             
-            // Update aria attributes
+            // Update aria attributes.
             const isExpanded = $toggle.attr('aria-expanded') === 'true';
             $toggle.attr('aria-expanded', !isExpanded);
             
-            // Store expanded state in browser storage
+            // Store expanded state in browser storage.
             const version = $header.data('version');
             if (version) {
                 const expandedVersions = getExpandedVersions();
                 
                 if (isExpanded) {
-                    // Remove from expanded versions
+                    // Remove from expanded versions.
                     const index = expandedVersions.indexOf(version);
                     if (index !== -1) {
                         expandedVersions.splice(index, 1);
                     }
                 } else {
-                    // Add to expanded versions
+                    // Add to expanded versions.
                     if (!expandedVersions.includes(version)) {
                         expandedVersions.push(version);
                     }
                 }
                 
-                // Save updated list
+                // Save updated list.
                 saveExpandedVersions(expandedVersions);
             }
         });
         
-        // Handle section header clicks
+        // Handle section header clicks.
         $('.stellar-changelog-embed__section-header').on('click', function() {
             const $header = $(this);
             const $section = $header.closest('.stellar-changelog-embed__section');
             const $changes = $section.find('.stellar-changelog-embed__changes');
             
-            // Toggle display
+            // Toggle display.
             $changes.slideToggle(200);
             
-            // Toggle aria attribute
+            // Toggle aria attribute.
             const isExpanded = $header.attr('aria-expanded') === 'true';
             $header.attr('aria-expanded', !isExpanded);
         });
         
-        // Set initial states based on stored preferences
+        // Set initial states based on stored preferences.
         restoreExpandedVersions();
     }
     
     /**
-     * Initialize pagination for a changelog viewer
+     * Initialize pagination for a changelog viewer.
+	 * 
+	 * @since 2.0.0
      * 
-     * @param {jQuery} $viewer The changelog viewer element
+     * @param {jQuery} $viewer The changelog viewer element.
+	 * 
+	 * @return void
      */
     function initPagination($viewer) {
         const versionsPerPage = parseInt($viewer.data('versions-per-page')) || 5;
         const totalVersions = parseInt($viewer.data('total-versions')) || 0;
         
         if (totalVersions <= versionsPerPage) {
-            return; // No pagination needed
+            return; // No pagination needed.
         }
         
         let currentPage = 1;
         const totalPages = Math.ceil(totalVersions / versionsPerPage);
         
-        // Show first page initially
+        // Show first page initially.
         showPage($viewer, currentPage, versionsPerPage);
         
-        // Handle pagination button clicks
+        // Handle pagination button clicks.
         $viewer.on('click', '.stellar-changelog-embed__pagination-btn', function(e) {
             e.preventDefault();
             const $btn = $(this);
@@ -109,17 +123,21 @@
             showPage($viewer, currentPage, versionsPerPage);
             updatePaginationControls($viewer, currentPage, totalPages);
             
-            // Scroll to top of changelog
+            // Scroll to top of changelog.
             $viewer[0].scrollIntoView({ behavior: 'smooth', block: 'start' });
         });
     }
     
     /**
-     * Show specific page of changelog versions
+     * Show specific page of changelog versions.
+	 * 
+	 * @since 2.0.0
      * 
-     * @param {jQuery} $viewer The changelog viewer element
-     * @param {number} page The page number to show
-     * @param {number} versionsPerPage Number of versions per page
+     * @param {jQuery} $viewer The changelog viewer element.
+     * @param {number} page The page number to show.
+     * @param {number} versionsPerPage Number of versions per page.
+	 * 
+	 * @return void
      */
     function showPage($viewer, page, versionsPerPage) {
         const $versions = $viewer.find('.stellar-changelog-embed__version');
@@ -135,7 +153,7 @@
             }
         });
         
-        // Update pagination info
+        // Update pagination info.
         const $paginationText = $viewer.find('.wp-changelog-pagination-text .current-page');
         if ($paginationText.length) {
             $paginationText.text(page);
@@ -144,29 +162,37 @@
     
     /**
      * Update pagination controls state
+	 * 
+	 * @since 2.0.0
      * 
-     * @param {jQuery} $viewer The changelog viewer element
-     * @param {number} currentPage Current page number
-     * @param {number} totalPages Total number of pages
+     * @param {jQuery} $viewer The changelog viewer element.
+     * @param {number} currentPage Current page number.
+     * @param {number} totalPages Total number of pages.
+	 * 
+	 * @return void
      */
     function updatePaginationControls($viewer, currentPage, totalPages) {
         const $prevBtn = $viewer.find('.stellar-changelog-embed__pagination-prev');
         const $nextBtn = $viewer.find('.stellar-changelog-embed__pagination-next');
         const $numberBtns = $viewer.find('.stellar-changelog-embed__pagination-number');
         
-        // Update prev/next buttons
+        // Update prev/next buttons.
         $prevBtn.prop('disabled', currentPage <= 1);
         $nextBtn.prop('disabled', currentPage >= totalPages);
         
-        // Update number buttons
+        // Update number buttons.
         $numberBtns.removeClass('active');
         $numberBtns.filter(`[data-page="${currentPage}"]`).addClass('active');
     }
     
     /**
-     * Get array of expanded version numbers from localStorage
+     * Get array of expanded version numbers from localStorage.
+	 * 
+	 * @since 2.0.0
      * 
-     * @return {Array} List of expanded version numbers
+     * @return {Array} List of expanded version numbers.
+	 * 
+	 * @return void
      */
     function getExpandedVersions() {
         try {
@@ -179,9 +205,13 @@
     }
     
     /**
-     * Save array of expanded version numbers to localStorage
+     * Save array of expanded version numbers to localStorage.
+	 * 
+	 * @since 2.0.0
      * 
-     * @param {Array} versions List of expanded version numbers
+     * @param {Array} versions List of expanded version numbers.
+	 * 
+	 * @return void
      */
     function saveExpandedVersions(versions) {
         try {
@@ -192,12 +222,16 @@
     }
     
     /**
-     * Restore expanded state of versions from localStorage
+     * Restore expanded state of versions from localStorage.
+	 * 
+	 * @since 2.0.0
+	 * 
+	 * @return void
      */
     function restoreExpandedVersions() {
         const expandedVersions = getExpandedVersions();
         
-        // First collapse all versions (except the latest if no preferences exist)
+        // First collapse all versions (except the latest if no preferences exist).
         $('.stellar-changelog-embed__version:visible').each(function(index) {
             const $version = $(this);
             const $header = $version.find('.stellar-changelog-embed__version-header');
@@ -205,18 +239,18 @@
             const $toggle = $header.find('.stellar-changelog-embed__toggle');
             const version = $header.data('version');
             
-            // Determine if this version should be expanded
+            // Determine if this version should be expanded.
             let shouldBeExpanded;
             
             if (expandedVersions.length > 0) {
-                // Use stored preferences
+                // Use stored preferences.
                 shouldBeExpanded = expandedVersions.includes(version);
             } else {
-                // Default: only expand latest version (first visible one)
+                // Default: only expand latest version (first visible one).
                 shouldBeExpanded = index === 0;
             }
             
-            // Set initial state
+            // Set initial state.
             if (!shouldBeExpanded) {
                 $content.hide();
                 $toggle.attr('aria-expanded', 'false');
@@ -224,7 +258,7 @@
         });
     }
     
-    // Initialize when DOM is fully loaded
+    // Initialize when DOM is fully loaded.
     $(document).ready(function() {
         initChangelog();
     });

--- a/src/modules/blocks/changelog-embed/frontend.js
+++ b/src/modules/blocks/changelog-embed/frontend.js
@@ -1,0 +1,232 @@
+/**
+ * Frontend JavaScript for Changelog Viewer
+ * 
+ * Handles toggling of changelog versions, sections, and pagination
+ */
+(function($) {
+    'use strict';
+    
+    /**
+     * Initialize the changelog functionality
+     */
+    function initChangelog() {
+        // Initialize pagination for each changelog viewer
+        $('.wp-changelog-viewer').each(function() {
+            initPagination($(this));
+        });
+        
+        // Handle version header clicks
+        $('.stellar-changelog-embed__version-header').on('click', function() {
+            const $header = $(this);
+            const $version = $header.closest('.stellar-changelog-embed__version');
+            const $content = $version.find('.stellar-changelog-embed__version-content');
+            const $toggle = $header.find('.stellar-changelog-embed__toggle');
+            
+            // Toggle display
+            $content.slideToggle(200);
+            
+            // Update aria attributes
+            const isExpanded = $toggle.attr('aria-expanded') === 'true';
+            $toggle.attr('aria-expanded', !isExpanded);
+            
+            // Store expanded state in browser storage
+            const version = $header.data('version');
+            if (version) {
+                const expandedVersions = getExpandedVersions();
+                
+                if (isExpanded) {
+                    // Remove from expanded versions
+                    const index = expandedVersions.indexOf(version);
+                    if (index !== -1) {
+                        expandedVersions.splice(index, 1);
+                    }
+                } else {
+                    // Add to expanded versions
+                    if (!expandedVersions.includes(version)) {
+                        expandedVersions.push(version);
+                    }
+                }
+                
+                // Save updated list
+                saveExpandedVersions(expandedVersions);
+            }
+        });
+        
+        // Handle section header clicks
+        $('.stellar-changelog-embed__section-header').on('click', function() {
+            const $header = $(this);
+            const $section = $header.closest('.stellar-changelog-embed__section');
+            const $changes = $section.find('.stellar-changelog-embed__changes');
+            
+            // Toggle display
+            $changes.slideToggle(200);
+            
+            // Toggle aria attribute
+            const isExpanded = $header.attr('aria-expanded') === 'true';
+            $header.attr('aria-expanded', !isExpanded);
+        });
+        
+        // Set initial states based on stored preferences
+        restoreExpandedVersions();
+    }
+    
+    /**
+     * Initialize pagination for a changelog viewer
+     * 
+     * @param {jQuery} $viewer The changelog viewer element
+     */
+    function initPagination($viewer) {
+        const versionsPerPage = parseInt($viewer.data('versions-per-page')) || 5;
+        const totalVersions = parseInt($viewer.data('total-versions')) || 0;
+        
+        if (totalVersions <= versionsPerPage) {
+            return; // No pagination needed
+        }
+        
+        let currentPage = 1;
+        const totalPages = Math.ceil(totalVersions / versionsPerPage);
+        
+        // Show first page initially
+        showPage($viewer, currentPage, versionsPerPage);
+        
+        // Handle pagination button clicks
+        $viewer.on('click', '.stellar-changelog-embed__pagination-btn', function(e) {
+            e.preventDefault();
+            const $btn = $(this);
+            
+            if ($btn.prop('disabled')) {
+                return;
+            }
+            
+            if ($btn.hasClass('stellar-changelog-embed__pagination-prev')) {
+                currentPage = Math.max(1, currentPage - 1);
+            } else if ($btn.hasClass('stellar-changelog-embed__pagination-next')) {
+                currentPage = Math.min(totalPages, currentPage + 1);
+            } else if ($btn.hasClass('stellar-changelog-embed__pagination-number')) {
+                currentPage = parseInt($btn.data('page'));
+            }
+            
+            showPage($viewer, currentPage, versionsPerPage);
+            updatePaginationControls($viewer, currentPage, totalPages);
+            
+            // Scroll to top of changelog
+            $viewer[0].scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+    }
+    
+    /**
+     * Show specific page of changelog versions
+     * 
+     * @param {jQuery} $viewer The changelog viewer element
+     * @param {number} page The page number to show
+     * @param {number} versionsPerPage Number of versions per page
+     */
+    function showPage($viewer, page, versionsPerPage) {
+        const $versions = $viewer.find('.stellar-changelog-embed__version');
+        const startIndex = (page - 1) * versionsPerPage;
+        const endIndex = startIndex + versionsPerPage;
+        
+        $versions.each(function(index) {
+            const $version = $(this);
+            if (index >= startIndex && index < endIndex) {
+                $version.show();
+            } else {
+                $version.hide();
+            }
+        });
+        
+        // Update pagination info
+        const $paginationText = $viewer.find('.wp-changelog-pagination-text .current-page');
+        if ($paginationText.length) {
+            $paginationText.text(page);
+        }
+    }
+    
+    /**
+     * Update pagination controls state
+     * 
+     * @param {jQuery} $viewer The changelog viewer element
+     * @param {number} currentPage Current page number
+     * @param {number} totalPages Total number of pages
+     */
+    function updatePaginationControls($viewer, currentPage, totalPages) {
+        const $prevBtn = $viewer.find('.stellar-changelog-embed__pagination-prev');
+        const $nextBtn = $viewer.find('.stellar-changelog-embed__pagination-next');
+        const $numberBtns = $viewer.find('.stellar-changelog-embed__pagination-number');
+        
+        // Update prev/next buttons
+        $prevBtn.prop('disabled', currentPage <= 1);
+        $nextBtn.prop('disabled', currentPage >= totalPages);
+        
+        // Update number buttons
+        $numberBtns.removeClass('active');
+        $numberBtns.filter(`[data-page="${currentPage}"]`).addClass('active');
+    }
+    
+    /**
+     * Get array of expanded version numbers from localStorage
+     * 
+     * @return {Array} List of expanded version numbers
+     */
+    function getExpandedVersions() {
+        try {
+            const stored = localStorage.getItem('stellar_changelog_embed_expanded');
+            return stored ? JSON.parse(stored) : [];
+        } catch (e) {
+            console.error('Error reading changelog preferences', e);
+            return [];
+        }
+    }
+    
+    /**
+     * Save array of expanded version numbers to localStorage
+     * 
+     * @param {Array} versions List of expanded version numbers
+     */
+    function saveExpandedVersions(versions) {
+        try {
+            localStorage.setItem('stellar_changelog_embed_expanded', JSON.stringify(versions));
+        } catch (e) {
+            console.error('Error saving changelog preferences', e);
+        }
+    }
+    
+    /**
+     * Restore expanded state of versions from localStorage
+     */
+    function restoreExpandedVersions() {
+        const expandedVersions = getExpandedVersions();
+        
+        // First collapse all versions (except the latest if no preferences exist)
+        $('.stellar-changelog-embed__version:visible').each(function(index) {
+            const $version = $(this);
+            const $header = $version.find('.stellar-changelog-embed__version-header');
+            const $content = $version.find('.stellar-changelog-embed__version-content');
+            const $toggle = $header.find('.stellar-changelog-embed__toggle');
+            const version = $header.data('version');
+            
+            // Determine if this version should be expanded
+            let shouldBeExpanded;
+            
+            if (expandedVersions.length > 0) {
+                // Use stored preferences
+                shouldBeExpanded = expandedVersions.includes(version);
+            } else {
+                // Default: only expand latest version (first visible one)
+                shouldBeExpanded = index === 0;
+            }
+            
+            // Set initial state
+            if (!shouldBeExpanded) {
+                $content.hide();
+                $toggle.attr('aria-expanded', 'false');
+            }
+        });
+    }
+    
+    // Initialize when DOM is fully loaded
+    $(document).ready(function() {
+        initChangelog();
+    });
+    
+})(jQuery);

--- a/src/modules/blocks/changelog-embed/index.js
+++ b/src/modules/blocks/changelog-embed/index.js
@@ -11,6 +11,9 @@ import { registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
 import metadata from './block.json';
 
+// Ensures the CSS is built.
+import './style.css';
+
 /**
  * Every block starts by registering a new block type definition.
  *

--- a/src/modules/blocks/changelog-embed/style.css
+++ b/src/modules/blocks/changelog-embed/style.css
@@ -1,5 +1,7 @@
 /**
  * Changelog Viewer Styles
+ * 
+ * TODO: Convert to SCSS in a separate PR.
  */
 
 .stellar-changelog-embed__viewer {

--- a/src/modules/blocks/changelog-embed/style.css
+++ b/src/modules/blocks/changelog-embed/style.css
@@ -1,0 +1,432 @@
+/**
+ * Changelog Viewer Styles
+ */
+
+.stellar-changelog-embed__viewer {
+    max-width: 100%;
+    margin: 0 auto;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    color: #333;
+}
+
+/* Changelog header */
+.stellar-changelog-embed__viewer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.stellar-changelog-embed__viewer-title {
+    font-size: 1.8rem;
+    margin: 0;
+    font-weight: 600;
+}
+
+.stellar-changelog-embed__pagination-info {
+    color: #64748b;
+    font-size: 0.875rem;
+}
+
+.stellar-changelog-embed__pagination-info .current-page {
+    font-weight: 600;
+    color: #1e40af;
+}
+
+/* Version container */
+.stellar-changelog-embed__version {
+    margin-bottom: 2rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.375rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+}
+
+/* Version header */
+.stellar-changelog-embed__version-header {
+    padding: 1rem;
+    background-color: #f8fafc;
+    border-bottom: 1px solid #e2e8f0;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.stellar-changelog-embed__version-info {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.stellar-changelog-embed__version-title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1a202c;
+}
+
+.stellar-changelog-embed__version-date {
+    color: #64748b;
+    font-size: 0.875rem;
+    display: flex;
+    align-items: center;
+}
+
+.stellar-changelog-embed__version-date::before {
+    content: '';
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    margin-right: 0.25rem;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>');
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.stellar-changelog-embed__version-tag {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: uppercase;
+}
+
+.stellar-changelog-embed__version-latest {
+    background-color: #ebf5ff;
+    color: #1e40af;
+}
+
+.stellar-changelog-embed__toggle {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.5rem;
+    color: #64748b;
+    transition: transform 0.2s;
+}
+
+.stellar-changelog-embed__toggle:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(66, 153, 225, 0.5);
+}
+
+.stellar-changelog-embed__toggle-icon {
+    display: block;
+    width: 14px;
+    height: 14px;
+    position: relative;
+}
+
+.stellar-changelog-embed__toggle-icon::before,
+.stellar-changelog-embed__toggle-icon::after {
+    content: '';
+    position: absolute;
+    background-color: currentColor;
+    transition: transform 0.2s;
+}
+
+.stellar-changelog-embed__toggle-icon::before {
+    top: 6px;
+    left: 0;
+    width: 14px;
+    height: 2px;
+}
+
+.stellar-changelog-embed__toggle-icon::after {
+    top: 0;
+    left: 6px;
+    width: 2px;
+    height: 14px;
+}
+
+.stellar-changelog-embed__toggle[aria-expanded="false"] .stellar-changelog-embed__toggle-icon::after {
+    transform: rotate(90deg);
+}
+
+/* Version content */
+.stellar-changelog-embed__version-content {
+    padding: 1rem;
+    background-color: #fff;
+}
+
+/* Sections (grouped by type) */
+.stellar-changelog-embed__section {
+    margin-bottom: 1.5rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.25rem;
+    overflow: hidden;
+}
+
+.stellar-changelog-embed__section:last-child {
+    margin-bottom: 0;
+}
+
+.stellar-changelog-embed__section-header {
+    margin: 0;
+    padding: 0.75rem 1rem;
+    background-color: #f8fafc;
+    font-size: 1rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: pointer;
+    user-select: none;
+}
+
+.stellar-changelog-embed__section-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #2d3748;
+}
+
+.stellar-changelog-embed__section-count {
+    background-color: #e2e8f0;
+    color: #4a5568;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.125rem 0.375rem;
+    border-radius: 9999px;
+    min-width: 1.5rem;
+    text-align: center;
+}
+
+/* Change list */
+.stellar-changelog-embed__changes {
+    margin: 0;
+    padding: 1rem;
+    list-style-type: none;
+}
+
+.stellar-changelog-embed__change {
+    position: relative;
+    padding-left: 1rem;
+    margin-bottom: 0.75rem;
+    line-height: 1.5;
+}
+
+.stellar-changelog-embed__change:last-child {
+    margin-bottom: 0;
+}
+
+.stellar-changelog-embed__change::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.65rem;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: #a0aec0;
+}
+
+/* Type-specific colors */
+.stellar-changelog-embed__section[data-type="Fix"] .stellar-changelog-embed__section-header {
+    background-color: #fee2e2;
+}
+
+.stellar-changelog-embed__section[data-type="Fix"] .stellar-changelog-embed__section-title {
+    color: #991b1b;
+}
+
+.stellar-changelog-embed__section[data-type="Fix"] .stellar-changelog-embed__section-count {
+    background-color: #fecaca;
+    color: #b91c1c;
+}
+
+.stellar-changelog-embed__section[data-type="Tweak"] .stellar-changelog-embed__section-header {
+    background-color: #dcfce7;
+}
+
+.stellar-changelog-embed__section[data-type="Tweak"] .stellar-changelog-embed__section-title {
+    color: #166534;
+}
+
+.stellar-changelog-embed__section[data-type="Tweak"] .stellar-changelog-embed__section-count {
+    background-color: #bbf7d0;
+    color: #15803d;
+}
+
+.stellar-changelog-embed__section[data-type="Feature"] .stellar-changelog-embed__section-header {
+    background-color: #e0e7ff;
+}
+
+.stellar-changelog-embed__section[data-type="Feature"] .stellar-changelog-embed__section-title {
+    color: #3730a3;
+}
+
+.stellar-changelog-embed__section[data-type="Feature"] .stellar-changelog-embed__section-count {
+    background-color: #c7d2fe;
+    color: #4338ca;
+}
+
+.stellar-changelog-embed__section[data-type="Security"] .stellar-changelog-embed__section-header {
+    background-color: #fef3c7;
+}
+
+.stellar-changelog-embed__section[data-type="Security"] .stellar-changelog-embed__section-title {
+    color: #92400e;
+}
+
+.stellar-changelog-embed__section[data-type="Security"] .stellar-changelog-embed__section-count {
+    background-color: #fde68a;
+    color: #b45309;
+}
+
+/* Error messages */
+.stellar-changelog-embed__viewer-error {
+    padding: 1rem;
+    border-left: 4px solid #ef4444;
+    background-color: #fee2e2;
+    color: #b91c1c;
+    margin-bottom: 1rem;
+}
+
+/* Code formatting */
+.stellar-changelog-embed__change code {
+    background-color: #f1f5f9;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.875em;
+    color: #e11d48;
+    border: 1px solid #e2e8f0;
+    white-space: nowrap;
+    overflow-wrap: break-word;
+    word-break: break-all;
+}
+
+/* Mobile responsive code blocks */
+@media (max-width: 768px) {
+    .stellar-changelog-embed__change code {
+        white-space: normal;
+        word-break: break-all;
+        overflow-wrap: anywhere;
+        line-height: 1.4;
+    }
+}
+
+/* Bold and italic formatting */
+.stellar-changelog-embed__change strong {
+    font-weight: 600;
+}
+
+.stellar-changelog-embed__change em {
+    font-style: italic;
+}
+
+/* Editor specific styles */
+.stellar-changelog-embed__viewer-editor .stellar-changelog-embed__viewer-preview-note {
+    background-color: #f0f9ff;
+    border-left: 4px solid #0ea5e9;
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+    font-style: italic;
+    color: #0369a1;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .stellar-changelog-embed__version-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .stellar-changelog-embed__toggle {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+    }
+    
+    .stellar-changelog-embed__version-info {
+        padding-right: 2rem;
+    }
+    
+    .stellar-changelog-embed__viewer-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .stellar-changelog-embed__pagination-controls {
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+    
+    .stellar-changelog-embed__pagination-numbers {
+        order: -1;
+    }
+}
+
+/* Pagination styles */
+.stellar-changelog-embed__pagination {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e2e8f0;
+}
+
+.stellar-changelog-embed__pagination-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+}
+
+.stellar-changelog-embed__pagination-btn {
+    background: #ffffff;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #374151;
+    transition: all 0.2s;
+    min-width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+}
+
+.stellar-changelog-embed__pagination-btn:hover:not(:disabled) {
+    background-color: #f9fafb;
+    border-color: #9ca3af;
+    color: #111827;
+}
+
+.stellar-changelog-embed__pagination-btn:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
+    color: #111827;
+}
+
+.stellar-changelog-embed__pagination-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    color: #9ca3af;
+}
+
+.stellar-changelog-embed__pagination-btn.active {
+    background-color: #3b82f6;
+    border-color: #3b82f6;
+    color: #ffffff !important;
+    font-weight: 600;
+}
+
+.stellar-changelog-embed__pagination-btn.active:hover {
+    background-color: #2563eb;
+    border-color: #2563eb;
+    color: #ffffff !important;
+}
+
+.stellar-changelog-embed__pagination-numbers {
+    display: flex;
+    gap: 0.25rem;
+}

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -23,7 +23,7 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 	<div class="stellar-changelog-embed__no-entries">
 		<?php esc_html_e( 'No changelog entries found.', 'stellar-changelog-embed' ); ?>
 	</div>
-<?php else: ?>
+<?php else : ?>
 	<div
 		class="stellar-changelog-embed" 
 		data-versions-per-page="<?php echo esc_attr( $versions_per_page ); ?>" 
@@ -110,7 +110,7 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 						
 						<?php // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited -- This does not apply to this file. ?>
 						<?php foreach ( $grouped_changes as $type => $changes ) : ?>
-							<div class="stellar-changelog-embed__section">
+							<div class="stellar-changelog-embed__section" data-type="<?php echo esc_attr( $type ); ?>">
 								<h4 class="stellar-changelog-embed__section-header">
 									<span class="stellar-changelog-embed__section-title">
 										<?php echo esc_html( Helper::pluralize_type( $type ) ); ?>


### PR DESCRIPTION
Selectors have been corrected and the alternate header color functionality that existed within the styles has been restored.

Example of the alternate header colors:

<img width="1210" height="803" alt="image" src="https://github.com/user-attachments/assets/444ebd70-de50-4d9e-9095-ba19fefd7dce" />