### PR TITLE
Improve Accessibility

### DIFF
--- a/src/modules/blocks/changelog-embed/frontend.js
+++ b/src/modules/blocks/changelog-embed/frontend.js
@@ -181,8 +181,8 @@
         $nextBtn.prop('disabled', currentPage >= totalPages);
         
         // Update number buttons.
-        $numberBtns.removeClass('active');
-        $numberBtns.filter(`[data-page="${currentPage}"]`).addClass('active');
+        $numberBtns.removeClass('active').removeAttr('aria-current');
+        $numberBtns.filter(`[data-page="${currentPage}"]`).addClass('active').attr('aria-current', 'page');
     }
     
     /**

--- a/src/modules/blocks/changelog-embed/frontend.js
+++ b/src/modules/blocks/changelog-embed/frontend.js
@@ -26,11 +26,11 @@
         });
         
         // Handle version header clicks.
-        $('.stellar-changelog-embed__version-header').on('click', function() {
-            const $header = $(this);
+        $('.stellar-changelog-embed__toggle').on('click touch', function() {
+            const $header = $(this).closest('.stellar-changelog-embed__version-header');
             const $version = $header.closest('.stellar-changelog-embed__version');
             const $content = $version.find('.stellar-changelog-embed__version-content');
-            const $toggle = $header.find('.stellar-changelog-embed__toggle');
+            const $toggle = $(this);
             
             // Toggle display.
             $content.slideToggle(200);
@@ -63,8 +63,8 @@
         });
         
         // Handle section header clicks.
-        $('.stellar-changelog-embed__section-header').on('click', function() {
-            const $header = $(this);
+        $('.stellar-changelog-embed__section-count').on('click touch', function() {
+            const $header = $(this).closest('.stellar-changelog-embed__section-header');
             const $section = $header.closest('.stellar-changelog-embed__section');
             const $changes = $section.find('.stellar-changelog-embed__changes');
             
@@ -72,8 +72,8 @@
             $changes.slideToggle(200);
             
             // Toggle aria attribute.
-            const isExpanded = $header.attr('aria-expanded') === 'true';
-            $header.attr('aria-expanded', !isExpanded);
+            const isExpanded = $(this).attr('aria-expanded') === 'true';
+            $(this).attr('aria-expanded', !isExpanded);
         });
         
         // Set initial states based on stored preferences.

--- a/src/modules/blocks/changelog-embed/style.css
+++ b/src/modules/blocks/changelog-embed/style.css
@@ -373,10 +373,18 @@
 }
 
 .stellar-changelog-embed__pagination-controls {
-    display: flex;
-    justify-content: center;
+	list-style: none;
+	margin: 0;
+	padding: 0;
     align-items: center;
+    display: flex;
     gap: 1rem;
+    justify-content: center;
+}
+
+.stellar-changelog-embed__pagination-controls li {
+	display: inline-block;
+	list-style-type: none;
 }
 
 .stellar-changelog-embed__pagination-btn {
@@ -426,9 +434,4 @@
     background-color: #2563eb;
     border-color: #2563eb;
     color: #ffffff !important;
-}
-
-.stellar-changelog-embed__pagination-numbers {
-    display: flex;
-    gap: 0.25rem;
 }

--- a/src/modules/blocks/changelog-embed/style.css
+++ b/src/modules/blocks/changelog-embed/style.css
@@ -146,7 +146,7 @@
     height: 14px;
 }
 
-.stellar-changelog-embed__toggle[aria-expanded="false"] .stellar-changelog-embed__toggle-icon::after {
+.stellar-changelog-embed__toggle[aria-expanded="true"] .stellar-changelog-embed__toggle-icon::after {
     transform: rotate(90deg);
 }
 

--- a/src/modules/blocks/changelog-embed/style.css
+++ b/src/modules/blocks/changelog-embed/style.css
@@ -51,7 +51,6 @@
     padding: 1rem;
     background-color: #f8fafc;
     border-bottom: 1px solid #e2e8f0;
-    cursor: pointer;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -177,7 +176,6 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    cursor: pointer;
     user-select: none;
 }
 

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -178,39 +178,53 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 		</div>
 		
 		<?php if ( $total_pages > 1 ) : ?>
-			<div class="stellar-changelog-embed__pagination">
-				<div class="stellar-changelog-embed__pagination-controls">
-					<button type="button" class="stellar-changelog-embed__pagination-btn stellar-changelog-embed__pagination-btn--prev" disabled>
-						<span aria-hidden="true">&laquo;</span>
-						<span class="screen-reader-text">
-							<?php esc_html_e( 'Previous page', 'stellar-changelog-embed' ); ?>
-						</span>
-					</button>
-					
-					<div class="stellar-changelog-embed__pagination-numbers">
-						<?php for ( $i = 1; $i <= $total_pages; $i++ ) : ?>
+			<nav
+				class="stellar-changelog-embed__pagination"
+				aria-label="<?php esc_html_e( 'Pagination for version details.', 'stellar-changelog-embed' ); ?>"
+			>
+				<ul class="stellar-changelog-embed__pagination-controls">
+					<li>
+						<button type="button" class="stellar-changelog-embed__pagination-btn stellar-changelog-embed__pagination-btn--prev" disabled>
+							<span aria-hidden="true">&laquo;</span>
+							<span class="screen-reader-text">
+								<?php esc_html_e( 'Previous page', 'stellar-changelog-embed' ); ?>
+							</span>
+						</button>
+					</li>
+
+					<?php for ( $i = 1; $i <= $total_pages; $i++ ) : ?>
+						<li>
 							<button
 								type="button" 
 								class="stellar-changelog-embed__pagination-btn stellar-changelog-embed__pagination-btn--number <?php echo $i === 1 ? 'stellar-changelog-embed__pagination-btn--active' : ''; ?>" 
 								data-page="<?php echo esc_attr( $i ); ?>"
+								<?php if ( $i === 1 ) : ?>
+									aria-current="page"
+								<?php endif; ?>
 							>
+								<span class="screen-reader-text">
+									<?php esc_html_e( 'Page', 'stellar-changelog-embed' ); ?> 
+								</span>
+
 								<?php echo esc_html( $i ); ?>
 							</button>
-						<?php endfor; ?>
-					</div>
+						</li>
+					<?php endfor; ?>
 
-					<button
-						class="stellar-changelog-embed__pagination-btn stellar-changelog-embed__pagination-btn--next" 
-						<?php echo $total_pages <= 1 ? 'disabled' : ''; ?>
-						type="button" 
-					>
-						<span aria-hidden="true">&raquo;</span>
-						<span class="screen-reader-text">
-							<?php esc_html_e( 'Next page', 'stellar-changelog-embed' ); ?>
-						</span>
-					</button>
-				</div>
-			</div>
+					<li>
+						<button
+							class="stellar-changelog-embed__pagination-btn stellar-changelog-embed__pagination-btn--next" 
+							<?php echo $total_pages <= 1 ? 'disabled' : ''; ?>
+							type="button" 
+						>
+							<span aria-hidden="true">&raquo;</span>
+							<span class="screen-reader-text">
+								<?php esc_html_e( 'Next page', 'stellar-changelog-embed' ); ?>
+							</span>
+						</button>
+					</li>
+				</ul>
+			</nav>
 		<?php endif; ?>
 	</div>
 <?php endif; ?>

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -37,7 +37,11 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 			
 			<?php if ( $total_pages > 1 ) : ?>
 				<div class="stellar-changelog-embed__pagination-info">
-					<span class="stellar-changelog-embed__pagination-text">
+					<span
+						aria-live="polite"
+						class="stellar-changelog-embed__pagination-text"
+						id="stellar-changelog-embed__pagination-text"
+					>
 						<?php esc_html_e( 'Page', 'stellar-changelog-embed' ); ?> 
 						<span class="stellar-changelog-embed__current-page">1</span> 
 						<?php esc_html_e( 'of', 'stellar-changelog-embed' ); ?> 
@@ -181,6 +185,8 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 			<nav
 				class="stellar-changelog-embed__pagination"
 				aria-label="<?php esc_html_e( 'Pagination for version details.', 'stellar-changelog-embed' ); ?>"
+				aria-labelledby="stellar-changelog-embed__pagination stellar-changelog-embed__pagination-text"
+				id="stellar-changelog-embed__pagination"
 			>
 				<ul class="stellar-changelog-embed__pagination-controls">
 					<li>

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -49,7 +49,10 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 		</div>
 		
 		<div class="stellar-changelog-embed__versions">
-			<?php foreach ( $changelog_data as $index => $version ) : ?>
+			<?php
+			foreach ( $changelog_data as $index => $version ) :
+				$version_id = wp_generate_uuid4();
+				?>
 					<div 
 					class="stellar-changelog-embed__version" 
 						data-version-index="<?php echo esc_attr( $index ); ?>" 
@@ -88,7 +91,12 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 							<?php endif; ?>
 						</div>
 						
-						<button type="button" class="stellar-changelog-embed__toggle" aria-expanded="true">
+						<button
+							aria-expanded="true"
+							aria-controls="stellar-changelog-embed__version-content--<?php echo esc_attr( $version_id ); ?>"
+							class="stellar-changelog-embed__toggle"
+							type="button"
+						>
 							<span class="screen-reader-text">
 								<?php esc_html_e( 'Toggle changelog details', 'stellar-changelog-embed' ); ?>
 							</span>
@@ -96,7 +104,10 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 						</button>
 					</div>
 					
-					<div class="stellar-changelog-embed__version-content">
+					<div
+						class="stellar-changelog-embed__version-content"
+						id="stellar-changelog-embed__version-content--<?php echo esc_attr( $version_id ); ?>"
+					>
 						<?php
 						// Group changes by type.
 						$grouped_changes = [];
@@ -115,12 +126,34 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 									<span class="stellar-changelog-embed__section-title">
 										<?php echo esc_html( Helper::pluralize_type( $type ) ); ?>
 									</span>
-									<span class="stellar-changelog-embed__section-count">
-										<?php echo count( $changes ); ?>
-									</span>
+									<button
+										aria-expanded="true"
+										aria-controls="stellar-changelog-embed__changes--<?php echo esc_attr( $version_id ); ?>-<?php echo esc_attr( strtolower( $type ) ); ?>"
+										class="stellar-changelog-embed__section-count"
+										type="button"
+									>
+										<span class="screen-reader-text">
+											<?php
+											echo esc_html(
+												sprintf(
+													// translators: %1$d: Number of changes. %2$s: Section title.
+													__( 'Toggle %1$d %2$s', 'stellar-changelog-embed' ),
+													count( $changes ),
+													Helper::pluralize_type( $type )
+												)
+											);
+											?>
+										</span>
+										<span aria-hidden="true">
+											<?php echo esc_html( count( $changes ) ); ?>
+										</span>
+									</button>
 								</h4>
 								
-								<ul class="stellar-changelog-embed__changes">
+								<ul
+									class="stellar-changelog-embed__changes"
+									id="stellar-changelog-embed__changes--<?php echo esc_attr( $version_id ); ?>-<?php echo esc_attr( strtolower( $type ) ); ?>"
+								>
 									<?php foreach ( $changes as $change ) : ?>
 										<li class="stellar-changelog-embed__change">
 											<?php // TODO: Investigate what the previous code did here. ?>

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -148,9 +148,15 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 											<?php
 											echo esc_html(
 												sprintf(
-													// translators: %1$d: Number of changes. %2$s: Section title. %3$s: Version number.
-													__( 'Toggle %1$d %2$s for version %3$s.', 'stellar-changelog-embed' ),
+													// translators: %1$d: Number of changes. %2$s: Section title singular. %3$s: Section title plural. %4$s: Version number.
+													_n( // phpcs:ignore WordPress.WP.I18n.MismatchedPlaceholders -- It's intentional to allow proper translation.
+														'Toggle %1$d %2$s for version %4$s.',
+														'Toggle %1$d %3$s for version %4$s.',
+														count( $changes ),
+														'stellar-changelog-embed'
+													),
 													count( $changes ),
+													$type,
 													Helper::pluralize_type( $type ),
 													$version['version']
 												)

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -98,7 +98,15 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 							type="button"
 						>
 							<span class="screen-reader-text">
-								<?php esc_html_e( 'Toggle changelog details', 'stellar-changelog-embed' ); ?>
+								<?php
+								echo esc_html(
+									sprintf(
+										// translators: %s: Version number.
+										__( 'Toggle version %s changelog details.', 'stellar-changelog-embed' ),
+										$version['version']
+									)
+								);
+								?>
 							</span>
 							<span class="stellar-changelog-embed__toggle-icon" aria-hidden="true"></span>
 						</button>
@@ -136,10 +144,11 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 											<?php
 											echo esc_html(
 												sprintf(
-													// translators: %1$d: Number of changes. %2$s: Section title.
-													__( 'Toggle %1$d %2$s', 'stellar-changelog-embed' ),
+													// translators: %1$d: Number of changes. %2$s: Section title. %3$s: Version number.
+													__( 'Toggle %1$d %2$s for version %3$s.', 'stellar-changelog-embed' ),
 													count( $changes ),
-													Helper::pluralize_type( $type )
+													Helper::pluralize_type( $type ),
+													$version['version']
 												)
 											);
 											?>

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -102,7 +102,7 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 								echo esc_html(
 									sprintf(
 										// translators: %s: Version number.
-										__( 'Toggle version %s changelog details.', 'stellar-changelog-embed' ),
+										__( 'Toggle version %s details.', 'stellar-changelog-embed' ),
 										$version['version']
 									)
 								);


### PR DESCRIPTION
- Fixed Expand/Collapse Buttons
    - Improved labels
    - Added missing `aria-controls`
    - Now correctly shows "Plus" to Expand and "Minus" to Collapse instead of the opposite
- Individual "Types" within a changelog are now keyboard navigable (Switched to a proper `<button>`)
    - This is less obvious to non-accessibility devices as it is just the number that is the button, but without substantial DOM/design changes I am not sure if we can do much better.
    - Realistically, I figure users will be wanting to expand/collapse the whole version more often than individual "Types" anyway. This ends up being more useful for screen readers/keyboard navigation.
- Converted Pagination to a `<nav>` and added the appropriate `aria` attributes

I confirmed that Accordion content is properly hidden from screen readers when collapsed and you cannot tab into their content (such as if a link was placed within a changelog item), so there are no concerns there. 

📹 https://www.loom.com/share/5d50f55c131a4994bf3fedd06d32c3ec