### PR TITLE
Loosen Changelog type matches

### DIFF
--- a/src/ChangelogEmbed/Changelog_Parser.php
+++ b/src/ChangelogEmbed/Changelog_Parser.php
@@ -65,9 +65,9 @@ class Changelog_Parser {
 
 			// Process change entries (e.g., "* Fix - Fixed an issue...").
 			if ( $current_version !== null &&
-				preg_match( '/^\*\s*([\w\-]+)\s*-\s*(.+)$/i', $line, $matches ) ) {
+				preg_match( '/^(?:[\*|-]\s*)(?:([\w\-]+)\s*-)?\s*(.+)$/i', $line, $matches ) ) {
 
-				$type    = trim( $matches[1] );
+				$type    = ! empty( trim( $matches[1] ) ) ? trim( $matches[1] ) : __( 'Change', 'stellar-changelog-embed' );
 				$content = trim( $matches[2] );
 
 				$content = $this->escape_shortcodes( $content );


### PR DESCRIPTION
1. Lines can now start with either `-` or `*`.
2. If a Type is not detected, `Change` will be used by default so that the changelog item is not lost.

Tested with:

```txt
= [2.0.0] 2025-08-11 =

- Feature - Breaking change! The changelog is now fetched from Github repositories. No need to update the files anymore. If you previously had the block configured, it will need to be reconfigured to be pointed to GitHub.
* Feature - A GitHub Personal Access Token can be entered under Settings -> StellarWP Changelog Viewer to increase rate limits.
* Tweak - Added filters: `stellar_changelog_embed_cache_duration`, `stellar_changelog_embed_supported_file_types`, `stellar_changelog_embed_type_plurals`.

= [1.0.0] 2024-10-03 =

- Initial release.
```

<img width="1232" height="777" alt="image" src="https://github.com/user-attachments/assets/ab979d28-0c0f-4fb2-a112-d6cc3ca61beb" />