### PR TITLE
DQA Changes

### DIFF
--- a/src/modules/blocks/changelog-embed/frontend.js
+++ b/src/modules/blocks/changelog-embed/frontend.js
@@ -20,11 +20,6 @@
 	 * @return {void}
      */
     function initChangelog() {
-        // Initialize pagination for each changelog viewer.
-        $('.stellar-changelog-embed').each(function() {
-            initPagination($(this));
-        });
-        
         // Handle version header clicks.
         $('.stellar-changelog-embed__toggle--version').on('click touch', function() {
             const $header = $(this).closest('.stellar-changelog-embed__version-header');
@@ -38,28 +33,6 @@
             // Update aria attributes.
             const isExpanded = $toggle.attr('aria-expanded') === 'true';
             $toggle.attr('aria-expanded', !isExpanded);
-            
-            // Store expanded state in browser storage.
-            const version = $header.data('version');
-            if (version) {
-                const expandedVersions = getExpandedVersions();
-                
-                if (isExpanded) {
-                    // Remove from expanded versions.
-                    const index = expandedVersions.indexOf(version);
-                    if (index !== -1) {
-                        expandedVersions.splice(index, 1);
-                    }
-                } else {
-                    // Add to expanded versions.
-                    if (!expandedVersions.includes(version)) {
-                        expandedVersions.push(version);
-                    }
-                }
-                
-                // Save updated list.
-                saveExpandedVersions(expandedVersions);
-            }
         });
         
         // Handle section header clicks.
@@ -75,9 +48,11 @@
             const isExpanded = $(this).attr('aria-expanded') === 'true';
             $(this).attr('aria-expanded', !isExpanded);
         });
-        
-        // Set initial states based on stored preferences.
-        restoreExpandedVersions();
+
+        // Initialize pagination for each changelog viewer.
+        $('.stellar-changelog-embed').each(function() {
+            initPagination($(this));
+        });
     }
     
     /**
@@ -92,6 +67,9 @@
     function initPagination($viewer) {
         const versionsPerPage = parseInt($viewer.data('versions-per-page')) || 5;
         const totalVersions = parseInt($viewer.data('total-versions')) || 0;
+
+        // Show first page initially.
+        showPage($viewer, 1, versionsPerPage);
         
         if (totalVersions <= versionsPerPage) {
             return; // No pagination needed.
@@ -99,9 +77,6 @@
         
         $viewer.data('current-page', 1);
         const totalPages = Math.ceil(totalVersions / versionsPerPage);
-        
-        // Show first page initially.
-        showPage($viewer, 1, versionsPerPage);
         
         // Handle pagination button clicks.
         $viewer.on('click', '.stellar-changelog-embed__pagination-btn', function(e) {
@@ -148,6 +123,13 @@
             const $version = $(this);
             if (index >= startIndex && index < endIndex) {
                 $version.show();
+
+                // Ensure the first version on the page is expanded and the rest are collapsed.
+                if (index === startIndex) {
+                    $version.find('.stellar-changelog-embed__toggle--version[aria-expanded="false"]').trigger('click');
+                } else {
+                    $version.find('.stellar-changelog-embed__toggle--version[aria-expanded="true"]').trigger('click');
+                }
             } else {
                 $version.hide();
             }
@@ -183,79 +165,6 @@
         // Update number buttons.
         $numberBtns.removeClass('active').removeAttr('aria-current');
         $numberBtns.filter(`[data-page="${currentPage}"]`).addClass('active').attr('aria-current', 'page');
-    }
-    
-    /**
-     * Get array of expanded version numbers from localStorage.
-	 * 
-	 * @since 2.0.0
-     * 
-     * @return {Array} List of expanded version numbers.
-	 * 
-	 * @return void
-     */
-    function getExpandedVersions() {
-        try {
-            const stored = localStorage.getItem('stellar_changelog_embed_expanded');
-            return stored ? JSON.parse(stored) : [];
-        } catch (e) {
-            console.error('Error reading changelog preferences', e);
-            return [];
-        }
-    }
-    
-    /**
-     * Save array of expanded version numbers to localStorage.
-	 * 
-	 * @since 2.0.0
-     * 
-     * @param {Array} versions List of expanded version numbers.
-	 * 
-	 * @return void
-     */
-    function saveExpandedVersions(versions) {
-        try {
-            localStorage.setItem('stellar_changelog_embed_expanded', JSON.stringify(versions));
-        } catch (e) {
-            console.error('Error saving changelog preferences', e);
-        }
-    }
-    
-    /**
-     * Restore expanded state of versions from localStorage.
-	 * 
-	 * @since 2.0.0
-	 * 
-	 * @return void
-     */
-    function restoreExpandedVersions() {
-        const expandedVersions = getExpandedVersions();
-        
-        // First collapse all versions (except the latest if no preferences exist).
-        $('.stellar-changelog-embed__version:visible').each(function(index) {
-            const $version = $(this);
-            const $header = $version.find('.stellar-changelog-embed__version-header');
-            const $content = $version.find('.stellar-changelog-embed__version-content');
-            const $toggle = $header.find('.stellar-changelog-embed__toggle');
-            const version = $header.data('version');
-            
-            // Determine if this version should be expanded.
-            let shouldBeExpanded;
-            
-            if (expandedVersions.length > 0) {
-                // Use stored preferences.
-                shouldBeExpanded = expandedVersions.includes(version);
-            } else {
-                // Default: only expand latest version (first visible one).
-                shouldBeExpanded = index === 0;
-            }
-            
-            // Set initial state.
-            if (!shouldBeExpanded) {
-                $content.hide();
-                $toggle.attr('aria-expanded', 'false');
-            }
-        });
     }
     
     // Initialize when DOM is fully loaded.

--- a/src/modules/blocks/changelog-embed/style.css
+++ b/src/modules/blocks/changelog-embed/style.css
@@ -338,6 +338,11 @@
     border-top: 1px solid #e2e8f0;
 }
 
+.stellar-changelog-embed__pagination .stellar-changelog-embed__pagination-info {
+    margin-bottom: 1rem;
+    text-align: center;
+}
+
 .stellar-changelog-embed__pagination-controls {
 	list-style: none;
 	margin: 0;

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -183,8 +183,8 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 											?>
 										</span>
 										<span class="stellar-changelog-embed__toggle-icon" aria-hidden="true">
-											<svg aria-hidden="true" class="stellar-changelog-embed__toggle-icon-svg" height="24" role="img" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-												<path fill-rule="evenodd" clip-rule="evenodd" d="M4.33474 8.36612C4.74672 7.91551 5.39498 7.88085 5.84331 8.26213L5.95098 8.36612L12 14.9813L18.049 8.36612C18.461 7.91551 19.1093 7.88085 19.5576 8.26213L19.6653 8.36612C20.0772 8.81672 20.1089 9.52576 19.7603 10.0161L19.6653 10.1339L12.8081 17.6339C12.3961 18.0845 11.7479 18.1192 11.2995 17.7379L11.1919 17.6339L4.33474 10.1339C3.88842 9.64573 3.88842 8.85427 4.33474 8.36612Z" fill="currentColor"></path>
+											<svg aria-hidden="true" class="stellar-changelog-embed__toggle-icon-svg"  width="24" height="24" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+												<path fill-rule="evenodd" clip-rule="evenodd" d="M5.8674 8.29289C6.19698 7.93241 6.71559 7.90468 7.07426 8.2097L7.16039 8.29289L11.9996 13.585L16.8388 8.29289C17.1684 7.93241 17.687 7.90468 18.0457 8.2097L18.1318 8.29289C18.4614 8.65338 18.4868 9.22061 18.2079 9.6129L18.1318 9.70711L12.6461 15.7071C12.3165 16.0676 11.7979 16.0953 11.4392 15.7903L11.3531 15.7071L5.8674 9.70711C5.51035 9.31658 5.51035 8.68342 5.8674 8.29289Z" fill="currentColor"/>
 											</svg>
 										</span>
 									</button>

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -36,7 +36,6 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 					<span
 						aria-live="polite"
 						class="stellar-changelog-embed__pagination-text"
-						id="stellar-changelog-embed__pagination-text"
 					>
 						<?php esc_html_e( 'Page', 'stellar-changelog-embed' ); ?> 
 						<span class="stellar-changelog-embed__current-page">1</span> 
@@ -210,6 +209,20 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 				aria-labelledby="stellar-changelog-embed__pagination stellar-changelog-embed__pagination-text"
 				id="stellar-changelog-embed__pagination"
 			>
+				<div class="stellar-changelog-embed__pagination-info">
+					<span
+						aria-live="polite"
+						class="stellar-changelog-embed__pagination-text"
+						id="stellar-changelog-embed__pagination-text"
+					>
+						<?php esc_html_e( 'Page', 'stellar-changelog-embed' ); ?> 
+						<span class="stellar-changelog-embed__current-page">1</span> 
+						<?php esc_html_e( 'of', 'stellar-changelog-embed' ); ?> 
+						<span class="stellar-changelog-embed__total-pages"><?php echo esc_html( $total_pages ); ?></span> 
+						(<?php echo esc_html( $total_versions ); ?> <?php esc_html_e( 'versions', 'stellar-changelog-embed' ); ?>)
+					</span>
+				</div>
+
 				<ul class="stellar-changelog-embed__pagination-controls">
 					<li>
 						<button type="button" class="stellar-changelog-embed__pagination-btn stellar-changelog-embed__pagination-btn--prev" disabled>

--- a/src/views/changelog.php
+++ b/src/views/changelog.php
@@ -31,10 +31,6 @@ $unique_id         = 'changelog-' . wp_rand( 1000, 9999 ); // Generate unique ID
 		id="<?php echo esc_attr( $unique_id ); ?>"
 	>
 		<div class="stellar-changelog-embed__header">
-			<h2 class="stellar-changelog-embed__title">
-				<?php esc_html_e( 'Changelog', 'stellar-changelog-embed' ); ?>
-			</h2>
-			
 			<?php if ( $total_pages > 1 ) : ?>
 				<div class="stellar-changelog-embed__pagination-info">
 					<span


### PR DESCRIPTION
- Change Types now use a smaller Caret icon
- The "Changelog" header has been removed
- A copy of the "Page X out of Y (Y versions)" text has been added directly above the pagination buttons
- Only the first version per-page is now auto-expanded
    - There was previously some logic for storing open/closed versions in localStorage, but it wasn't plugin-specific and could have caused issues with overlapping version numbers. It is best to just remove it and try to figure out something later if needed.

https://docs.google.com/spreadsheets/d/1RMbnYXeNb3eoiD8cyb9nIosVCr1qdil6SibSiRK5MHc/edit?gid=1496560870#gid=1496560870