### PR TITLE
Remove top margin

### DIFF
--- a/src/modules/blocks/changelog-embed/style.css
+++ b/src/modules/blocks/changelog-embed/style.css
@@ -20,7 +20,7 @@
 }
 
 .stellar-changelog-embed__versions {
-    margin-top: 1rem;
+    margin-bottom: 1rem;
 }
 
 /* Version container */
@@ -333,6 +333,7 @@
 /* Pagination styles */
 .stellar-changelog-embed__pagination {
     margin-top: 2rem;
+    margin-bottom: 1rem;
     padding-top: 1.5rem;
     border-top: 1px solid #e2e8f0;
 }


### PR DESCRIPTION
It was there for the header element previously, which no longer exists.

That margin has been moved to better account for multiple changelog blocks in a single container.